### PR TITLE
Workaround for kudu issue

### DIFF
--- a/HttpWorker-Node-Ping/Content/HttpWorkerNodePing/function.json
+++ b/HttpWorker-Node-Ping/Content/HttpWorkerNodePing/function.json
@@ -1,7 +1,7 @@
 {
   "bindings": [
     {
-      "authLevel": "function",
+      "authLevel": "anonymous",
       "type": "httpTrigger",
       "direction": "in",
       "name": "req",


### PR DESCRIPTION
Due to issue https://github.com/projectkudu/kudu/issues/3116 following code cannot set function key for HttpWorker test.
https://github.com/Azure/azure-functions-host/blob/dev/test/WebJobs.Script.Tests.E2E.Shared/FunctionAppFixture.cs#L127

Changing the test to be anonymous until kudu change is deployed
